### PR TITLE
Fixed Link visibility in Details View configuration being ignored

### DIFF
--- a/source/Views/DetailsViewGameOverview.xaml
+++ b/source/Views/DetailsViewGameOverview.xaml
@@ -194,7 +194,7 @@
                                     </DockPanel>
                                     <!--#regionend-->
                                 </Grid>
-                                <DockPanel Margin="0,20,0,15" MaxWidth="{DynamicResource DetailsViewDetailsMaxWidth}" Grid.Row="2" Background="Transparent"
+                                <DockPanel Margin="0,20,0,15" MaxWidth="{DynamicResource DetailsViewDetailsMaxWidth}" Grid.Row="2" Visibility="{Binding LinkVisibility}" Background="Transparent"
                                            x:Name="ButtonBar" Tag="{DynamicResource LinkBarAsBox}">
                                     <StackPanel VerticalAlignment="Bottom" DockPanel.Dock="Left">
                                         <WrapPanel Margin="0,15,0,0" Orientation="Horizontal">


### PR DESCRIPTION
The configuration in `Settings` → `Appearance` → `Links` is ignored when disabled. The bar with URLs is currently shown at all times. A change to following line of code fixes this issue.